### PR TITLE
Add some known issues Jorge has encountered and a validation python script 

### DIFF
--- a/gpu_report.rst
+++ b/gpu_report.rst
@@ -302,7 +302,7 @@ repository includes a Makefile for building the executable.
    cd MOM6-examples/ocean_only
    CC=nvc \
    FC=nvfortran \
-   FCFLAGS="-g -O0 -mp=gpu -stdpar=gpu -Mnofma -Minfo=all -gpu=mem:separate" \
+   FCFLAGS="-gopt -O0 -mp=gpu -stdpar=gpu -Mnofma -Minfo=all -gpu=mem:separate" \
    LDFLAGS="-mp=gpu" \
    make -j
 

--- a/issues-encountered.md
+++ b/issues-encountered.md
@@ -2,6 +2,8 @@
 
 ## Compiling your own stuff 
 
+*attention* netcdf built with 25.5 won't be picked up by MOM if building MOM with nvhpc 24.9. You'll need versioned installs. sorry
+
 ```
 git clone git@github.com:Unidata/netcdf-fortran.git
 git clone git@github.com:Unidata/netcdf-c.git

--- a/issues-encountered.md
+++ b/issues-encountered.md
@@ -2,10 +2,19 @@
 
 Contents:
 
+- High level TODOs
 - MOM6-examples known issues on GPUs
 - MPI related issues
 - NVHPC versions issues
 - How to compile NetCDF using CMake
+
+
+## High level TODOs
+
+- MOM6 examples seems to struggle with FMS2
+- MOM6 examples does not use latest FMS2
+- FMS2 latest CMake build system does not have a way to build the unit tests
+- FMS2 autoconf build fails lots of unit tests when compiling with NVHPC
 
 ## MOM6-examples issues on GPUs 
 

--- a/issues-encountered.md
+++ b/issues-encountered.md
@@ -1,44 +1,17 @@
 # ISSUES 
 
-## Compiling your own stuff 
+Contents:
 
-*attention* netcdf built with 25.5 won't be picked up by MOM if building MOM with nvhpc 24.9. You'll need versioned installs. sorry
+- MOM6-examples known issues on GPUs
+- MPI related issues
+- NVHPC versions issues
+- How to compile NetCDF using CMake
 
-```
-git clone git@github.com:Unidata/netcdf-fortran.git
-git clone git@github.com:Unidata/netcdf-c.git
-export nvhpc_verno=25.5
-export NETCDFC_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-c
-export NETCDFF_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-fortran
-cd netcdf-c
-mkdir build
-cd build 
-cmake -DCMAKE_INSTALL_PREFIX=$NETCDFC_ROOT -DCMAKE_BUILD_TYPE=Release ../
-make -j install
-cd ../../netcdf-fortran 
-mkdir build
-cd build
-	cmake -DCMAKE_INSTALL_PREFIX=$NETCDFF_ROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$NETCDFC_ROOT ../
-make -j install
-```
+## MOM6-examples issues on GPUs 
 
-Then...
+The version of FMS2 that is the default in MOM6 examples seems to be giving problems. You have to switch back to FMS1 by modifying the Makefile in `ocean_only` to point to FMS1: `FMS_CODEBASE ?= ../src/FMS1` 
 
-```
-#!/bin/bash
-
-export nvhpc_verno=25.5
-export NETCDFC_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-c
-export NETCDFF_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-fortran
-
-export PATH=$PATH:$NETCDFC_ROOT/bin
-export PATH=$PATH:$NETCDFF_ROOT/bin
-# check if your netcdf is pointing to lib64 or lib could be different
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDFC_ROOT/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDFF_ROOT/lib64
-```
-
-Now you can source the above file and have netcdf loaded, yay. 
+### FMS2 detailed issues (to be added)
 
 
 ## MPI related 
@@ -85,3 +58,43 @@ On 25.5 building and running the `double-gyre` example works well. However, runn
 ### 24.9 
 
 Both double gyre and benchmark seem to work well. 
+
+## Compiling your own stuff 
+
+*attention* netcdf built with 25.5 won't be picked up by MOM if building MOM with nvhpc 24.9. You'll need versioned installs. sorry
+
+```
+git clone git@github.com:Unidata/netcdf-fortran.git
+git clone git@github.com:Unidata/netcdf-c.git
+export nvhpc_verno=25.5
+export NETCDFC_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-c
+export NETCDFF_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-fortran
+cd netcdf-c
+mkdir build
+cd build 
+cmake -DCMAKE_INSTALL_PREFIX=$NETCDFC_ROOT -DCMAKE_BUILD_TYPE=Release ../
+make -j install
+cd ../../netcdf-fortran 
+mkdir build
+cd build
+	cmake -DCMAKE_INSTALL_PREFIX=$NETCDFF_ROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$NETCDFC_ROOT ../
+make -j install
+```
+
+Then...
+
+```
+#!/bin/bash
+
+export nvhpc_verno=25.5
+export NETCDFC_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-c
+export NETCDFF_ROOT=$PSCRATCH/install/nvfortran/${nvhpc_verno}/netcdf-fortran
+
+export PATH=$PATH:$NETCDFC_ROOT/bin
+export PATH=$PATH:$NETCDFF_ROOT/bin
+# check if your netcdf is pointing to lib64 or lib could be different
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDFC_ROOT/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDFF_ROOT/lib64
+```
+
+Now you can source the above file and have netcdf loaded, yay. 

--- a/issues-encountered.md
+++ b/issues-encountered.md
@@ -67,6 +67,10 @@ I've seen this error above when compiling with OpenMPI 5.0.5 on Gadi and both 4.
 
 ## NVHPC Version related 
 
+### Compute sanitizer and opt flags 
+
+Apparently using `-g` does not just add debug symbols but it might also hinder optimization. We have to use `-gopt`
+
 ### 25.5 
 
 On 25.5 building and running the `double-gyre` example works well. However, running the `benchmark` example produces mapping errors on the GPU values. Known bug, see [here](https://forums.developer.nvidia.com/t/bug-nvhpc-25-x-present-table-errors-with-fortran-do-concurrent-and-kind-of-nested-type-bound-procedures/333144)

--- a/issues-encountered.md
+++ b/issues-encountered.md
@@ -58,6 +58,13 @@ exactly when Open MPI kills them.
 
 I've seen this error above when compiling with OpenMPI 5.0.5 on Gadi and both 4.1.4 and 5.0.5 on a personal machine. The solution was to run the MOM6 executable as `mpirun -np 1 ../build/MOM6` and ta-da
 
+### Tested MPI versions 
+
+- Openmpi
+  - 4.1.4
+  - 4.1.7
+  - 5.0.5 
+
 ## NVHPC Version related 
 
 ### 25.5 

--- a/validate-double-gyre.py
+++ b/validate-double-gyre.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import sys
+import re
+
+# Hardcoded reference values (full precision)
+reference_energies = [
+    1.4237499351110218E-13,
+    4.5804317899616613E-06,
+    8.9582059515487157E-06,
+    1.1667077649757350E-05,
+    1.5422955375147519E-05,
+    1.8260222694485033E-05,
+    2.3974311229885696E-05,
+    2.9279621461764738E-05,
+    3.4864407126080987E-05,
+    4.1955651758640954E-05,
+    4.6047288874347594E-05
+]
+
+def extract_energy_mass(filename):
+    pattern = re.compile(r"En\s+([+-]?\d+\.\d+E[+-]]?\d+)")
+    energies = []
+
+    with open(filename, 'r') as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                energies.append(match.group(1).strip())
+
+    return energies
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: ./validate_energy_strict.py ocean.stats")
+        sys.exit(1)
+
+    filename = sys.argv[1]
+    extracted = extract_energy_mass(filename)
+
+    ref_str = [f"{v:.16E}" for v in reference_energies]
+
+    if len(extracted) != len(ref_str):
+        print(f"Mismatch in number of entries: {len(extracted)} vs {len(ref_str)}")
+        sys.exit(1)
+
+    all_good = True
+    for i, (val, ref) in enumerate(zip(extracted, ref_str)):
+        if val != ref:
+            print(f"Mismatch at step {i}: got {val}, expected {ref}")
+            all_good = False
+
+    if all_good:
+        print("All energy values match exactly.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Validation script uses values from double gyre CPU. And matches them it its entirety. Usage is `python validate-double-gyre.py ocean.stats` 